### PR TITLE
remove runtime dependency on Interop.TaskScheduler.dll

### DIFF
--- a/src/Elevate/Elevate.csproj
+++ b/src/Elevate/Elevate.csproj
@@ -85,7 +85,7 @@
       <Lcid>0</Lcid>
       <WrapperTool>tlbimp</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </COMReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Elevate/Program.cs
+++ b/src/Elevate/Program.cs
@@ -41,7 +41,7 @@ namespace Elevate
 				return 0;
 			}
 
-			ITaskService service = new TaskSchedulerClass();
+			ITaskService service = new TaskScheduler.TaskScheduler();
 			service.Connect(null, null, null, null);
 			var folder = service.GetFolder("\\");
 
@@ -83,7 +83,7 @@ namespace Elevate
 
 		private static void CreateSchedulerTask()
 		{
-			ITaskService service = new TaskSchedulerClass();
+			ITaskService service = new TaskScheduler.TaskScheduler();
 			service.Connect(null, null, null, null);
 			var folder = service.GetFolder("\\");
 


### PR DESCRIPTION
There is no need to deploy `Interop.TaskScheduler.dll` if the COM reference is configured with `EmbedInteropTypes`.